### PR TITLE
[0.1.4] FIX - Make the notification clickable on API 31+ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 ChangeLog
 ---------
-#### Version 0.9.0-beta.5
+### Vrsion 0.1.4 (2.11.2022)
+
+- FIX Bug 🐛 :bug
+  - Make notifications clickable on API 31+ by replacing the broadcast receiver by an activity used to start the main cordova activity.
+
+#### Important notice
+
+If the app is in background, it must not be launched but put in foreground.
+To avoid launching the app in this case, add the following in your config.xml file:
+`<preference name="AndroidLaunchMode" value="singleInstance"/>`
+## Special Thanks
+https://github.com/powowbox/cordova-plugin-local-notification-12
+
+#### Version 0.1.3
 - FIX Bug 🐛 :bug
   - Added missing 'PendingIntent.FLAG_MUTABLE' and fixed gradle
   - Guard against webview crash
@@ -8,9 +21,9 @@ ChangeLog
   - Delete Alarms when intent is deleted
   - Not calling delegate events if nil or if we're consuming the notifiction
   - Android 13 `POST_NOTIFICATIONS ` prmission and runtime popup added
-- Enhancements (Android)
-- New interfaces to ask for / register permissions required to schedule local notifications
- - New method addded for android `setDummyNotification()`
+  - Enhancements (Android)
+  - New interfaces to ask for / register permissions required to schedule local notifications
+  - New method addded for android `setDummyNotification()`
 
 #### Version 0.9.0-beta.4
 - Platform enhancements
@@ -159,3 +172,5 @@ Please also read the [Upgrade Guide](https://github.com/bhandaribhumin/cordova-p
 ### Version 0.8.0 (05.03.2015)
 
 Added condition to get view from view or engine [PR](https://github.com/bhandaribhumin/cordova-plugin-local-notification-12/pull/1)
+
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@
 
 ## Important Notice
 
+If the app is in background, it must not be launched but put in foreground.
+To avoid launching the app in this case, add the following in your config.xml file:
+`<preference name="AndroidLaunchMode" value="singleInstance"/>`
+
 Please make sure that you always read the tagged README for the version you're using.
 
 See the _0.8_ branch if you cannot upgrade. Further development for `v0.9-beta` will happen here. The `0.9-dev` and `ios10` branches are obsolate and will be removed soon.
@@ -64,6 +68,11 @@ __Known issues__
 
 Please report bugs or missing features!
 
+## Install
+```bash
+npm i cordova-plugin-local-notification-12
+cordova plugin add cordova-plugin-local-notification-12
+```
 
 ## Basics
 
@@ -544,11 +553,13 @@ See the sample app for how to use them.
 
 | Method   | Method            | Method          | Method         | Method        | Method           |
 | :------- | :---------------- | :-------------- | :------------- | :------------ | :--------------- |
-| schedule | cancelAll         | isTriggered     | get            | removeActions | un                              |
+| schedule | cancelAll         | isTriggered     | get            | removeActions |  un                              |
 | update   | hasPermission     | getType         | getAll         | hasActions    | fireQueuedEvents                |
 | clear    | requestPermission | getIds          | getScheduled   | getDefaults   | requestDoNotDisturbPermissions  |
 | clearAll | isPresent         | getScheduledIds | getTriggered   | setDefaults   | hasDoNotDisturbPermissions      |
 | cancel   | isScheduled       | getTriggeredIds | addActions     | on            |
+| setDummyNotifications | 
+
 
 ## SetDummyNotification
 
@@ -606,3 +617,5 @@ Made with :yum: from Leipzig
 [appplant]: http://appplant.de
 
 FIX: Added condition to get view from view or engine
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-local-notification-12",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Schedules and queries for local notifications",
   "cordova": {
     "id": "cordova-plugin-local-notification-12",

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-local-notification-12"
-        version="0.1.3">
+        version="0.1.4">
 
     <name>LocalNotification</name>
 
@@ -124,9 +124,10 @@
                 android:name="de.appplant.cordova.plugin.localnotification.ClearReceiver"
                 android:exported="false" />
 
-            <service
+            <activity
                 android:name="de.appplant.cordova.plugin.localnotification.ClickReceiver"
-                android:exported="false" />
+                android:exported="false"
+                android:theme="@style/Theme.AppCompat.NoActionBar" />
 
             <receiver
                 android:name="de.appplant.cordova.plugin.localnotification.RestoreReceiver"
@@ -199,6 +200,10 @@
             src="src/android/notification/receiver/AbstractTriggerReceiver.java"
             target-dir="src/de/appplant/cordova/plugin/notification/receiver" />
 
+        <source-file
+          src="src/android/notification/receiver/NotificationTrampolineActivity.java"
+          target-dir="src/de/appplant/cordova/plugin/notification/receiver" />
+          
         <source-file
             src="src/android/notification/trigger/DateTrigger.java"
             target-dir="src/de/appplant/cordova/plugin/notification/trigger" />

--- a/src/android/TriggerReceiver.java
+++ b/src/android/TriggerReceiver.java
@@ -85,8 +85,11 @@ public class TriggerReceiver extends AbstractTriggerReceiver {
      */
     @Override
     public Notification buildNotification(Builder builder, Bundle bundle) {
-        return builder.setClickActivity(ClickReceiver.class).setClearReceiver(ClearReceiver.class).setExtras(bundle)
-                .build();
+        return builder
+        .setClickActivity(ClickReceiver.class)
+        .setClearReceiver(ClearReceiver.class)
+        .setExtras(bundle)
+        .build();
     }
 
 }

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -40,9 +40,9 @@ import android.graphics.Paint;
 import android.graphics.Canvas;
 
 import java.util.List;
-import java.util.Random;
 
 import de.appplant.cordova.plugin.notification.action.Action;
+import de.appplant.cordova.plugin.notification.util.LaunchUtils;
 
 import static de.appplant.cordova.plugin.notification.Notification.EXTRA_UPDATE;
 
@@ -57,9 +57,6 @@ public final class Builder {
 
     // Notification options passed by JS
     private final Options options;
-
-    // To generate unique request codes
-    private final Random random = new Random();
 
     // Receiver to handle the clear event
     private Class<?> clearReceiver;
@@ -200,17 +197,7 @@ public final class Builder {
             .getLaunchIntentForPackage(pkgName)
             .putExtra("launchNotificationId", options.getId());
 
-        int reqCode = random.nextInt();
-        // request code and flags not added for demo purposes
-      int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-      if (android.os.Build.VERSION.SDK_INT <= 30) {
-        // null
-      }else{
-        flags = 33554432 | PendingIntent.FLAG_UPDATE_CURRENT;
-      }
-
-      PendingIntent pendingIntent = PendingIntent.getActivity(context, reqCode, intent, flags);
-
+        PendingIntent pendingIntent = LaunchUtils.getActivityPendingIntent(context, intent);
         builder.setFullScreenIntent(pendingIntent, true);
     }
 
@@ -402,18 +389,7 @@ public final class Builder {
             intent.putExtras(extras);
         }
 
-        int reqCode = random.nextInt();
-
-      int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-      if (android.os.Build.VERSION.SDK_INT <= 30) {
-        // null
-      }else{
-        flags = 33554432 | PendingIntent.FLAG_UPDATE_CURRENT;
-      }
-
-      PendingIntent deleteIntent = PendingIntent.getBroadcast(
-                context, reqCode, intent, flags);
-
+        PendingIntent deleteIntent = LaunchUtils.getBroadcastPendingIntent(context, intent);
         builder.setDeleteIntent(deleteIntent);
     }
 
@@ -428,6 +404,13 @@ public final class Builder {
         if (clickActivity == null)
             return;
 
+        Action[] actions = options.getActions();
+        if (actions != null && actions.length > 0 ) {
+          // if actions are defined, the user must click on button actions to launch the app.
+          // Don't make the notification clickable in this case
+          return;
+        }
+
         Intent intent = new Intent(context, clickActivity)
                 .putExtra(Notification.EXTRA_ID, options.getId())
                 .putExtra(Action.EXTRA_ID, Action.CLICK_ACTION_ID)
@@ -438,18 +421,7 @@ public final class Builder {
             intent.putExtras(extras);
         }
 
-        int reqCode = random.nextInt();
-
-      int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-      if (android.os.Build.VERSION.SDK_INT <= 30) {
-        // null
-      }else{
-        flags = 33554432 | PendingIntent.FLAG_UPDATE_CURRENT;
-      }
-
-      PendingIntent contentIntent = PendingIntent.getService(
-                context, reqCode, intent, flags);
-
+        PendingIntent contentIntent = LaunchUtils.getTaskStackPendingIntent(context, intent);
         builder.setContentIntent(contentIntent);
     }
 
@@ -495,17 +467,7 @@ public final class Builder {
             intent.putExtras(extras);
         }
 
-        int reqCode = random.nextInt();
-
-      int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-      if (android.os.Build.VERSION.SDK_INT <= 30) {
-        // null
-      }else{
-        flags = 33554432 | PendingIntent.FLAG_UPDATE_CURRENT;
-      }
-
-      return PendingIntent.getService(
-                context, reqCode, intent, flags);
+      return LaunchUtils.getTaskStackPendingIntent(context, intent);
     }
 
     /**

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -29,7 +29,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.media.AudioManager;
 import android.net.Uri;
 import android.service.notification.StatusBarNotification;
 import android.util.Pair;
@@ -44,12 +43,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import androidx.collection.ArraySet;
 import androidx.core.app.NotificationCompat;
 
@@ -60,7 +53,8 @@ import static android.os.Build.VERSION_CODES.M;
 import static androidx.core.app.NotificationCompat.PRIORITY_HIGH;
 import static androidx.core.app.NotificationCompat.PRIORITY_MAX;
 import static androidx.core.app.NotificationCompat.PRIORITY_MIN;
-import static java.lang.Thread.sleep;
+
+import de.appplant.cordova.plugin.notification.util.LaunchUtils;
 
 /**
  * Wrapper class around OS notification class. Handles basic operations
@@ -225,14 +219,7 @@ public final class Notification {
             if (!date.after(new Date()) && trigger(intent, receiver))
                 continue;
 
-            int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-            if (android.os.Build.VERSION.SDK_INT <= 30) {
-              // null
-            }else{
-              flags = 33554432 | PendingIntent.FLAG_UPDATE_CURRENT;
-            }
-            PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, flags);
+            PendingIntent pi = LaunchUtils.getBroadcastPendingIntent(context, intent);
 
             try {
                 switch (options.getPrio()) {
@@ -318,17 +305,7 @@ public final class Notification {
 
         for (String action : actions) {
             Intent intent = new Intent(action);
-
-          int flags = PendingIntent.FLAG_UPDATE_CURRENT;
-          if (android.os.Build.VERSION.SDK_INT <= 30) {
-            // null
-          }else{
-            flags = 33554432 | PendingIntent.FLAG_UPDATE_CURRENT;
-          }
-
-            PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, flags);
-
+            PendingIntent pi = LaunchUtils.getBroadcastPendingIntent(context, intent);
             if (pi != null) {
                 getAlarmMgr().cancel(pi);
             }

--- a/src/android/notification/receiver/AbstractClickReceiver.java
+++ b/src/android/notification/receiver/AbstractClickReceiver.java
@@ -22,7 +22,6 @@
 
 package de.appplant.cordova.plugin.notification.receiver;
 
-import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -30,8 +29,6 @@ import android.os.Bundle;
 import de.appplant.cordova.plugin.notification.Manager;
 import de.appplant.cordova.plugin.notification.Notification;
 
-import static android.content.Intent.FLAG_ACTIVITY_REORDER_TO_FRONT;
-import static android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP;
 import static de.appplant.cordova.plugin.notification.action.Action.CLICK_ACTION_ID;
 import static de.appplant.cordova.plugin.notification.action.Action.EXTRA_ID;
 
@@ -39,21 +36,22 @@ import static de.appplant.cordova.plugin.notification.action.Action.EXTRA_ID;
  * Abstract content receiver activity for local notifications. Creates the
  * local notification and calls the event functions for further proceeding.
  */
-abstract public class AbstractClickReceiver extends IntentService {
-
-    // Holds a reference to the intent to handle.
-    private Intent intent;
+abstract public class AbstractClickReceiver extends NotificationTrampolineActivity {
 
     public AbstractClickReceiver() {
-        super("LocalNotificationClickReceiver");
+      super();
+    }
+
+    public void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      onHandleIntent(getIntent());
     }
 
     /**
      * Called when local notification was clicked to launch the main intent.
      */
-    @Override
     protected void onHandleIntent(Intent intent) {
-        this.intent        = intent;
+      // Holds a reference to the intent to handle.
 
         if (intent == null)
             return;
@@ -71,7 +69,6 @@ abstract public class AbstractClickReceiver extends IntentService {
             return;
 
         onClick(toast, bundle);
-        this.intent = null;
     }
 
     /**
@@ -87,12 +84,5 @@ abstract public class AbstractClickReceiver extends IntentService {
      */
     protected String getAction() {
         return getIntent().getExtras().getString(EXTRA_ID, CLICK_ACTION_ID);
-    }
-
-    /**
-     * Getter for the received intent.
-     */
-    protected Intent getIntent() {
-        return intent;
     }
 }

--- a/src/android/notification/receiver/NotificationTrampolineActivity.java
+++ b/src/android/notification/receiver/NotificationTrampolineActivity.java
@@ -1,0 +1,43 @@
+package de.appplant.cordova.plugin.notification.receiver;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+
+
+/**
+ * To satitisfy the new android 12 requirement, the broadcast receiver used
+ * to handle click action on a notification, is replaced with a trampoline activity
+ * Note: to handle correctly the case where the application is running in background 
+ * while the action is clicked, set 
+ *  <preference name="AndroidLaunchMode" value="singleInstance"/>
+ *  in the config.xml file.
+ * If you don't add this line, the app is restarted
+ */
+public class NotificationTrampolineActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String packageName = this.getPackageName();
+        Intent launchIntent = this.getPackageManager().getLaunchIntentForPackage(packageName);
+        String mainActivityClassName = launchIntent.getComponent().getClassName();
+        Class mainActivityClass = null;
+        try {
+          mainActivityClass = Class.forName(mainActivityClassName);
+        } catch (ClassNotFoundException e) {
+          e.printStackTrace();
+          return;
+        }
+
+        Intent intent = new Intent(this, mainActivityClass);
+
+        // put activity from stack or instance it it doesn't exist
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(intent);
+    }
+}

--- a/src/android/notification/util/LaunchUtils.java
+++ b/src/android/notification/util/LaunchUtils.java
@@ -1,5 +1,7 @@
 package de.appplant.cordova.plugin.notification.util;
 
+import android.app.PendingIntent;
+import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
 
@@ -7,7 +9,42 @@ import static android.content.Intent.FLAG_ACTIVITY_REORDER_TO_FRONT;
 import static android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP;
 import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
 
+import java.util.Random;
+
 public final class LaunchUtils {
+
+   private static final Random _random = new Random();
+   private static int getRandomCode() {
+     return _random.nextInt();
+   }
+
+   private static int getIntentFlags() {
+        int FLAG_MUTABLE = 33554432; // don't use pendingIntent.FLAG_MUTABLE, use numeric value instead to be able to compile api < 31
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (android.os.Build.VERSION.SDK_INT >= 31) {
+          flags |= FLAG_MUTABLE;
+        }
+        return flags;
+    }
+
+    public static PendingIntent getServicePendingIntent(Context context, Intent intent) {
+      return  PendingIntent.getService(context, getRandomCode(), intent, getIntentFlags());
+    }
+
+    public static PendingIntent getBroadcastPendingIntent(Context context, Intent intent) {
+        return  PendingIntent.getBroadcast(context, getRandomCode(), intent, getIntentFlags());
+    }
+
+    public static PendingIntent getActivityPendingIntent(Context context, Intent intent) {
+        return  PendingIntent.getActivity(context, getRandomCode(), intent, getIntentFlags());
+    }
+
+    public static  PendingIntent getTaskStackPendingIntent(Context context, Intent intent) {
+        TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+        taskStackBuilder.addNextIntentWithParentStack(intent);
+        return taskStackBuilder.getPendingIntent(getRandomCode(), getIntentFlags());
+    }
+
 
     /***
      * Launch main intent from package.


### PR DESCRIPTION
Make notifications clickable on API 31+ by replacing the broadcast receiver with an activity used to start the main Cordova activity.